### PR TITLE
Simplify the module to just use cb(null, file.clone())

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,37 @@
 'use strict';
 
-var through = require('through2');
+var through = require('through2'),
+    gutil   = require('gulp-util');
 
-module.exports = function() {
+var cloneStream = function() {
     return through.obj(function(file, enc, cb) {
         cb(null, file.clone());
     });
 };
+
+var cloneSink = function() {
+    var tapStream = through.obj();
+
+    var stream = through.obj(function(file, enc, cb) {
+        if (file.isStream()) {
+            this.emit('error', new gutil.PluginError('gulp-clone', 'Streaming not supported'));
+            return cb();
+        }
+
+        if (file.isNull()) {
+            return cb(null, file);  // Do nothing if no contents
+        }
+
+        tapStream.write(file.clone());
+        cb(null, file);
+    });
+
+    stream.tap = function() {
+        return tapStream;
+    };
+
+    return stream;
+};
+
+module.exports = cloneStream;
+module.exports.sink = cloneSink;

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
     }
   ],
   "dependencies": {
+    "gulp-util": "~2.2.14",
     "through2": "~0.4.1"
   },
   "devDependencies": {
     "chai": "~1.9.0",
-    "gulp-util": "~2.2.14",
     "mocha": "~1.17.1"
   },
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -40,4 +40,28 @@ describe('gulp-clone', function() {
 
         sourceStream.end();
     });
+    it('should clone files in the stream, using the old behaviour', function(done) {
+        var sink   = clone.sink(),
+            buffer = [];
+
+        sink
+            .pipe(sink.tap())
+            .pipe(through.obj(function(f,e,cb) {
+                buffer.push(f);
+                cb(null, f);
+            }))
+            .on('finish', function() {
+                expect(buffer).to.have.length(2);
+                expect(buffer).to.have.deep.property('0.path', 'afile.js');
+                expect(buffer).to.have.deep.property('1.path', 'afile.js');
+                done();
+            });
+
+        sink.write(new gutil.File({
+            path: 'afile.js',
+            contents: new Buffer("")
+        }));
+
+        sink.end();
+    });
 });


### PR DESCRIPTION
See this issue https://github.com/ben-eb/gulp-rsvg/pull/2

Tested this out and it works pretty well. It lets you compose gulp tasks like so:

``` js
var gulp   = require('gulp');
    clone  = require('gulp-clone');
    concat = require('gulp-concat');
    es     = require('event-stream');
    uglify = require('gulp-uglify');

gulp.task('scripts', function() {
    var stream = gulp.src('*.js').pipe(concat('main.js'));

    var minify = stream
        .pipe(clone())
        .pipe(uglify())
        .pipe(gulp.dest('prod'));

    return es.merge(stream.pipe(gulp.dest('dev')), minify);
});
```

This would allow you to create two JS bundles; one concatenated and one concatenated and minified. :smiley:
