### PR TITLE
End tapStream when main stream ends

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,9 @@ var cloneSink = function() {
 
         tapStream.write(file.clone());
         cb(null, file);
+    }, function (cb) {
+        tapStream.end();
+        cb();
     });
 
     stream.tap = function() {

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ var cloneSink = function(options) {
         tapStream.write(file.clone());
         cb(null, file);
     }, function (cb) {
-        if (options && options.endTapStream) {
+        if (options && options.readableOnly) {
             tapStream.end();
         }
         cb();

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var cloneStream = function() {
     });
 };
 
-var cloneSink = function() {
+var cloneSink = function(options) {
     var tapStream = through.obj();
 
     var stream = through.obj(function(file, enc, cb) {
@@ -25,7 +25,9 @@ var cloneSink = function() {
         tapStream.write(file.clone());
         cb(null, file);
     }, function (cb) {
-        tapStream.end();
+        if (options && options.endTapStream) {
+            tapStream.end();
+        }
         cb();
     });
 


### PR DESCRIPTION
End tap stream when main stream ends, so it can be used with other other plugins like `concat` which are waiting the stream to end to flush the files.