### PR TITLE
Revert back to through2 semver ~0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "gulp-util": "~2.2.14",
-    "through2": "^2.0.3"
+    "through2": "~0.4.1"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
This PR targets 1.x branch, lmk if that's not correct.

@mariocasciaro unfortunately it looks like the issue #7 was caused by gulp-clone changing through2 from `~0.4.1` to `^2.0.3` and 1.1.2 still uses `^2.0.3` so it does not solve the issue in semantic-ui.

Here's an example: https://github.com/jayphelps/semantic-gulp-clone-issue

After `npm install` runs (has a postinstall) there should be a `semantic/dist/semantic.css` but there is not because those build code paths don't run.

Changing through2 back solves the issue.

```
npm install

> semantic-gulp-clone-issue@0.0.1 build /Users/jphelps/Projects/jayphelps/semantic-gulp-clone-issue
> cd semantic && gulp build && ls -l dist && ls dist/semantic.css

[13:56:07] Using gulpfile ~/Projects/jayphelps/semantic-gulp-clone-issue/semantic/gulpfile.js
[13:56:07] Starting 'build'...
Building Semantic
[13:56:07] Starting 'build-javascript'...
Building Javascript
[13:56:07] Starting 'build-css'...
Building CSS
[13:56:07] Starting 'build-assets'...
Building assets
[13:56:08] Created: dist/components/site.js
[13:56:09] Created: dist/components/form.js
[13:56:09] Created: dist/components/site.min.js
[13:56:10] Created: dist/components/accordion.js
[13:56:10] Created: dist/components/form.min.js
[13:56:10] Created: dist/components/accordion.min.js
[13:56:10] Created: dist/components/checkbox.js
[13:56:10] Created: dist/components/checkbox.min.js
[13:56:10] Created: dist/components/dimmer.js
[13:56:10] Created: dist/components/dimmer.min.js
[13:56:10] Created: dist/components/dropdown.js
[13:56:11] Created: dist/components/dropdown.min.js
... etc ...
[13:56:29] Created: dist/components/statistic.min.css
[13:56:29] Created: dist/components/accordion.min.css
[13:56:29] Created: dist/components/accordion.css
[13:56:29] Created: dist/components/checkbox.css
[13:56:29] Created: dist/components/checkbox.min.css
[13:56:29] Created: dist/components/dimmer.css
[13:56:29] Created: dist/components/dimmer.min.css

drwxr-xr-x  108 jphelps  2119906183    3672 Jan 15 13:57 components
-rw-r--r--    1 jphelps  2119906183  746362 Jan 15 13:57 semantic.js
-rw-r--r--    1 jphelps  2119906183  279665 Jan 15 13:57 semantic.min.js
drwxr-xr-x    6 jphelps  2119906183     204 Jan 15 13:57 themes
ls: dist/semantic.css: No such file or directory
```
